### PR TITLE
chore(deps): fix missing typescript module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,6 +12093,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
+    },
     "ua-parser-js": {
       "version": "0.7.23",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@nuxt/typescript-runtime": "^2.0.1",
     "@nuxtjs/axios": "^5.12.2",
     "core-js": "^3.8.3",
-    "nuxt": "^2.14.12"
+    "nuxt": "^2.14.12",
+    "typescript": "^4.1.3"
   },
   "devDependencies": {
     "@nuxt/types": "^2.14.12",


### PR DESCRIPTION
I just typed in :
`npm install typescript`
Since I could not use npm start (got Nuxt Fatal Error. Error: Cannot find module 'typescript')
Installing typescript did the trick and solved the issue.